### PR TITLE
Add basic arbitrage engine models

### DIFF
--- a/ArbitrageOpportunity.swift
+++ b/ArbitrageOpportunity.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct ArbitrageOpportunity {
+    let tokenPair: String
+    let buyExchange: String
+    let sellExchange: String
+    let buyPrice: Double
+    let sellPrice: Double
+
+    var profit: Double {
+        sellPrice - buyPrice
+    }
+}

--- a/ArbitrageService.swift
+++ b/ArbitrageService.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct MarketQuote {
+    let exchange: String
+    let tokenPair: String
+    let price: Double
+}
+
+class ArbitrageService {
+    func findOpportunities(quotes: [MarketQuote], minProfit: Double = 0) -> [ArbitrageOpportunity] {
+        var opportunities: [ArbitrageOpportunity] = []
+        let grouped = Dictionary(grouping: quotes, by: { $0.tokenPair })
+        for (pair, pairQuotes) in grouped {
+            for buy in pairQuotes {
+                for sell in pairQuotes {
+                    guard buy.exchange != sell.exchange else { continue }
+                    let profit = sell.price - buy.price
+                    if profit >= minProfit {
+                        opportunities.append(
+                            ArbitrageOpportunity(
+                                tokenPair: pair,
+                                buyExchange: buy.exchange,
+                                sellExchange: sell.exchange,
+                                buyPrice: buy.price,
+                                sellPrice: sell.price
+                            )
+                        )
+                    }
+                }
+            }
+        }
+        return opportunities
+    }
+}

--- a/Portfolio.swift
+++ b/Portfolio.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct PortfolioPosition {
+    let token: String
+    var amount: Double
+}
+
+struct Portfolio {
+    private(set) var positions: [PortfolioPosition] = []
+
+    mutating func update(token: String, delta: Double) {
+        if let index = positions.firstIndex(where: { $0.token == token }) {
+            positions[index].amount += delta
+        } else {
+            positions.append(PortfolioPosition(token: token, amount: delta))
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # FlashArb
+
+## App Analysis and Ratings
+
+| Metric | Rating (1-10) | Notes |
+|-------|---------------|-------|
+| Innovation | 6 | Mobile flash-loan arbitrage is an uncommon concept but currently underdeveloped. |
+| Monetization | 2 | No monetization strategy or revenue features implemented. |
+| Creativity | 5 | Combining DeFi with an iOS interface shows promise but lacks execution. |
+| Scalability | 4 | Lacks backend and multi-exchange support to grow beyond a prototype. |
+| User Engagement | 3 | Interface and real-time feedback are absent, reducing user retention. |
+
+## Improvements Implemented
+
+- Added foundational arbitrage engine components:
+  - `ArbitrageOpportunity` model to describe trades and profit.
+  - `ArbitrageService` for scanning market quotes and discovering opportunities.
+  - `Portfolio` model for tracking token balances.
+
+## Next Steps Toward 10/10
+
+- Integrate with real exchange APIs for live pricing.
+- Build an engaging dashboard and execution flow.
+- Introduce subscription or fee-based monetization model.
+- Expand analytics and risk management features for advanced users.


### PR DESCRIPTION
## Summary
- add foundational `ArbitrageOpportunity`, `ArbitrageService`, and `Portfolio` models
- document app ratings and improvement roadmap

## Testing
- `swiftc -typecheck ArbitrageOpportunity.swift ArbitrageService.swift Portfolio.swift`


------
https://chatgpt.com/codex/tasks/task_e_68934d3e7dd88329a9ff654b6bb3cf3d