### PR TITLE
Add exchange API client and adapters

### DIFF
--- a/ArbitrageService.swift
+++ b/ArbitrageService.swift
@@ -7,7 +7,31 @@ struct MarketQuote {
 }
 
 class ArbitrageService {
-    func findOpportunities(quotes: [MarketQuote], minProfit: Double = 0) -> [ArbitrageOpportunity] {
+    private let adapters: [ExchangeAdapter]
+
+    init(adapters: [ExchangeAdapter]) {
+        self.adapters = adapters
+    }
+
+    func findOpportunities(for pair: String, minProfit: Double = 0) async throws -> [ArbitrageOpportunity] {
+        let quotes = try await withThrowingTaskGroup(of: MarketQuote.self) { group in
+            for adapter in adapters {
+                group.addTask {
+                    try await adapter.fetchTicker(pair: pair)
+                }
+            }
+
+            var results: [MarketQuote] = []
+            for try await quote in group {
+                results.append(quote)
+            }
+            return results
+        }
+
+        return evaluate(quotes: quotes, minProfit: minProfit)
+    }
+
+    private func evaluate(quotes: [MarketQuote], minProfit: Double = 0) -> [ArbitrageOpportunity] {
         var opportunities: [ArbitrageOpportunity] = []
         let grouped = Dictionary(grouping: quotes, by: { $0.tokenPair })
         for (pair, pairQuotes) in grouped {

--- a/Sources/Networking/BinanceAdapter.swift
+++ b/Sources/Networking/BinanceAdapter.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct BinanceAdapter: ExchangeAdapter {
+    let client: ExchangeAPIClient
+    let rateLimiter = RateLimiter(requestsPerSecond: 5)
+
+    var name: String { "Binance" }
+
+    func fetchTicker(pair: String) async throws -> MarketQuote {
+        let symbol = pair.replacingOccurrences(of: "/", with: "").uppercased()
+        let url = URL(string: "https://api.binance.com/api/v3/ticker/price?symbol=\(symbol)")!
+        struct Response: Decodable { let symbol: String; let price: String }
+        let response: Response = try await client.fetch(url, decode: Response.self, rateLimiter: rateLimiter)
+        return MarketQuote(exchange: name, tokenPair: pair, price: Double(response.price) ?? 0)
+    }
+}

--- a/Sources/Networking/CoinbaseAdapter.swift
+++ b/Sources/Networking/CoinbaseAdapter.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct CoinbaseAdapter: ExchangeAdapter {
+    let client: ExchangeAPIClient
+    let rateLimiter = RateLimiter(requestsPerSecond: 3)
+
+    var name: String { "Coinbase" }
+
+    func fetchTicker(pair: String) async throws -> MarketQuote {
+        let symbol = pair.replacingOccurrences(of: "/", with: "-").uppercased()
+        let url = URL(string: "https://api.coinbase.com/v2/prices/\(symbol)/spot")!
+        struct Response: Decodable {
+            struct Data: Decodable { let amount: String }
+            let data: Data
+        }
+        let response: Response = try await client.fetch(url, decode: Response.self, rateLimiter: rateLimiter)
+        return MarketQuote(exchange: name, tokenPair: pair, price: Double(response.data.amount) ?? 0)
+    }
+}

--- a/Sources/Networking/ExchangeAPIClient.swift
+++ b/Sources/Networking/ExchangeAPIClient.swift
@@ -1,0 +1,44 @@
+import Foundation
+import FoundationNetworking
+
+actor RateLimiter {
+    private var lastRequest: Date?
+    private let minimumInterval: TimeInterval
+
+    init(requestsPerSecond: Double) {
+        self.minimumInterval = 1.0 / requestsPerSecond
+    }
+
+    func wait() async {
+        let now = Date()
+        if let last = lastRequest {
+            let delta = now.timeIntervalSince(last)
+            if delta < minimumInterval {
+                let delay = UInt64((minimumInterval - delta) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: delay)
+            }
+        }
+        lastRequest = Date()
+    }
+}
+
+class ExchangeAPIClient {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetch<T: Decodable>(_ url: URL, decode type: T.Type, rateLimiter: RateLimiter? = nil) async throws -> T {
+        if let rateLimiter = rateLimiter {
+            await rateLimiter.wait()
+        }
+        let (data, response) = try await session.data(from: url)
+        guard let http = response as? HTTPURLResponse,
+              200..<300 ~= http.statusCode else {
+            throw URLError(.badServerResponse)
+        }
+        let decoder = JSONDecoder()
+        return try decoder.decode(T.self, from: data)
+    }
+}

--- a/Sources/Networking/ExchangeAdapter.swift
+++ b/Sources/Networking/ExchangeAdapter.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol ExchangeAdapter {
+    var name: String { get }
+    func fetchTicker(pair: String) async throws -> MarketQuote
+}


### PR DESCRIPTION
## Summary
- add generic `ExchangeAPIClient` with rate limiting and JSON decoding helpers
- implement `BinanceAdapter` and `CoinbaseAdapter` to fetch live market quotes
- refactor `ArbitrageService` to use exchange adapters for live opportunity scans

## Testing
- `swiftc -typecheck ArbitrageOpportunity.swift Portfolio.swift ArbitrageService.swift Sources/Networking/*.swift`


------
https://chatgpt.com/codex/tasks/task_e_689351789a348329a97c18f991b10523