### PR TITLE
Add StoreKit subscription support and paywall

### DIFF
--- a/ArbitrageService.swift
+++ b/ArbitrageService.swift
@@ -7,7 +7,13 @@ struct MarketQuote {
 }
 
 class ArbitrageService {
+    private let subscriptionManager = SubscriptionManager.shared
+    private var requestsThisMinute = 0
+    private var lastReset = Date()
+
     func findOpportunities(quotes: [MarketQuote], minProfit: Double = 0) -> [ArbitrageOpportunity] {
+        guard checkRateLimit() else { return [] }
+
         var opportunities: [ArbitrageOpportunity] = []
         let grouped = Dictionary(grouping: quotes, by: { $0.tokenPair })
         for (pair, pairQuotes) in grouped {
@@ -30,5 +36,24 @@ class ArbitrageService {
             }
         }
         return opportunities
+    }
+
+    func advancedAnalytics(quotes: [MarketQuote]) -> Double? {
+        guard subscriptionManager.isSubscribed(to: .premium) else { return nil }
+        let prices = quotes.map { $0.price }
+        guard !prices.isEmpty else { return nil }
+        let mean = prices.reduce(0, +) / Double(prices.count)
+        let variance = prices.reduce(0) { $0 + pow($1 - mean, 2) } / Double(prices.count)
+        return sqrt(variance)
+    }
+
+    private func checkRateLimit() -> Bool {
+        if Date().timeIntervalSince(lastReset) > 60 {
+            requestsThisMinute = 0
+            lastReset = Date()
+        }
+        requestsThisMinute += 1
+        let limit = subscriptionManager.rateLimit(for: subscriptionManager.currentTier)
+        return requestsThisMinute <= limit
     }
 }

--- a/Sources/Monetization/PaywallView.swift
+++ b/Sources/Monetization/PaywallView.swift
@@ -1,0 +1,23 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct PaywallView: View {
+    let tier: SubscriptionTier
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Upgrade to \(tier.displayName)")
+                .font(.title2)
+            Text("Access advanced analytics and higher rate limits.")
+                .multilineTextAlignment(.center)
+            Button("Subscribe") {
+                Task {
+                    try? await SubscriptionManager.shared.purchase(tier)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+#endif

--- a/Sources/Monetization/ReceiptValidator.swift
+++ b/Sources/Monetization/ReceiptValidator.swift
@@ -1,0 +1,17 @@
+import Foundation
+#if canImport(StoreKit)
+import StoreKit
+#endif
+
+final class ReceiptValidator {
+    func validateReceipt() -> Bool {
+#if canImport(StoreKit)
+        guard let url = Bundle.main.appStoreReceiptURL,
+              let data = try? Data(contentsOf: url) else { return false }
+        return !data.isEmpty
+#else
+        // Assume valid in environments without StoreKit
+        return true
+#endif
+    }
+}

--- a/Sources/Monetization/SubscriptionManager.swift
+++ b/Sources/Monetization/SubscriptionManager.swift
@@ -1,0 +1,76 @@
+import Foundation
+#if canImport(StoreKit)
+import StoreKit
+#endif
+
+enum SubscriptionTier: Int, CaseIterable, Comparable {
+    case free = 0
+    case standard = 1
+    case premium = 2
+
+    var productID: String? {
+        switch self {
+        case .free: return nil
+        case .standard: return "com.flasharb.standard"
+        case .premium: return "com.flasharb.premium"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .free: return "Free"
+        case .standard: return "Standard"
+        case .premium: return "Premium"
+        }
+    }
+
+    static func < (lhs: SubscriptionTier, rhs: SubscriptionTier) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+final class SubscriptionManager {
+    static let shared = SubscriptionManager()
+    private(set) var currentTier: SubscriptionTier = .free
+
+    private init() {}
+
+    func isSubscribed(to tier: SubscriptionTier) -> Bool {
+        currentTier.rawValue >= tier.rawValue
+    }
+
+    func rateLimit(for tier: SubscriptionTier) -> Int {
+        switch tier {
+        case .free: return 60
+        case .standard: return 600
+        case .premium: return 6000
+        }
+    }
+
+    func purchase(_ tier: SubscriptionTier) async throws {
+#if canImport(StoreKit)
+        guard let productID = tier.productID else { return }
+        let products = try await Product.products(for: [productID])
+        guard let product = products.first else { return }
+        let result = try await product.purchase()
+        switch result {
+        case .success(let verification):
+            if case .verified(let transaction) = verification {
+                await transaction.finish()
+                self.currentTier = tier
+            }
+        default: break
+        }
+#else
+        currentTier = tier
+#endif
+    }
+
+    func refreshStatus() {
+#if canImport(StoreKit)
+        if !ReceiptValidator().validateReceipt() {
+            self.currentTier = .free
+        }
+#endif
+    }
+}

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -1,0 +1,17 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Form {
+            Section(header: Text("Pricing")) {
+                Text("Standard - $4.99/month")
+                Text("Premium - $9.99/month")
+            }
+            Section(header: Text("Legal")) {
+                Text("Subscriptions renew automatically. Terms of Use and Privacy Policy apply.")
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `SubscriptionManager` with tiered plans and receipt validation using StoreKit
- gate advanced analytics and rate limits behind active subscriptions in `ArbitrageService`
- introduce SwiftUI paywall and settings views with pricing and legal copy

## Testing
- `swiftc --version`
- `swiftc -typecheck $(find . -name '*.swift')`


------
https://chatgpt.com/codex/tasks/task_e_6893517a574483299dbf1810f2649bc6