### PR TITLE
Fix README header and add getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-eeee# FlashArb
+# FlashArb
+
+FlashArb is a prototype iOS application that explores flash-loan arbitrage
+opportunities across decentralized exchanges. The project currently focuses on
+foundational components and does not yet integrate with live trading APIs.
+
+## Getting Started
+
+1. Clone the repository.
+2. Open `project.xcworkspace` in Xcode.
+3. Select an iOS simulator or device and run the app.
 
 ## App Analysis and Ratings
 


### PR DESCRIPTION
## Summary
- clean up malformed README header and add introductory description
- document basic steps for opening the project in Xcode

## Testing
- `swift build` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_6896a9fbe3c88329b1536a6fe8133000