### PR TITLE
Remove stray diagnostic string from ArbDetector

### DIFF
--- a/Services/ArbDetector.swift
+++ b/Services/ArbDetector.swift
@@ -4,7 +4,6 @@ enum ArbDetector {
     /// `minProfit` is a fraction (0.01 = 1%)
     static func detect(quotes: [MarketQuote], minProfit: Double) -> [ArbOpportunity] {
         guard quotes.count >= 2 else { return [] }
-        /Users/space/FlashArb/Services/ArbDetector.swift:5:70 'ArbOpportunity' is ambiguous for type lookup in this context
 
         // best buy = lowest price, best sell = highest price across exchanges
         guard let bestBuy  = quotes.min(by: { $0.price < $1.price }),


### PR DESCRIPTION
## Summary
- remove the stray diagnostic message from ArbDetector.detect
- keep surrounding whitespace lint-clean

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9378b7e0883298b1c0bfee0cbc64d