### PR TITLE
Use synchronous opportunity detection helper in dashboard refresh

### DIFF
--- a/ArbitrageOpportunity.swift
+++ b/ArbitrageOpportunity.swift
@@ -13,3 +13,10 @@ public struct ArbOpportunity: Identifiable, Hashable, Sendable {
     /// e.g. 0.012 = 1.2%
     public var spreadPct: Double { (sellPrice - buyPrice) / buyPrice }
 }
+
+public typealias ArbitrageOpportunity = ArbOpportunity
+
+public extension ArbOpportunity {
+    var tokenPair: String { pair }
+    var profit: Double { spread }
+}

--- a/ArbitrageService.swift
+++ b/ArbitrageService.swift
@@ -70,9 +70,13 @@ final class ArbitrageService {
         }
     }
 
+    func findOpportunities(quotes: [MarketQuote], minProfit: Double = 0) -> [ArbOpportunity] {
+        ArbDetector.detect(quotes: quotes, minProfit: minProfit)
+    }
+
     func findOpportunities(for pair: String, minProfit: Double = 0) async throws -> [ArbOpportunity] {
         guard await isSubscribed(.standard) else { return [] }
         let quotes = try await fetchQuotes(for: pair)
-        return ArbDetector.detect(quotes: quotes, minProfit: minProfit)
+        return findOpportunities(quotes: quotes, minProfit: minProfit)
     }
 }

--- a/Sources/UI/Dashboard/DashboardView.swift
+++ b/Sources/UI/Dashboard/DashboardView.swift
@@ -121,9 +121,10 @@ final class DashboardViewModel: ObservableObject {
         do {
             let pair = "ETH/DAI"
             let fetched = try await service.fetchQuotes(for: pair)
+            let detected = service.findOpportunities(quotes: fetched)
             await MainActor.run {
                 self.quotes = fetched
-                self.opportunities = service.findOpportunities(quotes: fetched)
+                self.opportunities = detected
             }
         } catch {
             print("Failed to fetch quotes: \(error)")


### PR DESCRIPTION
## Summary
- add a synchronous `findOpportunities(quotes:minProfit:)` helper to `ArbitrageService`
- reuse the helper in `DashboardViewModel.refreshData()` so the UI receives the detected opportunities
- expose a typealias and convenience accessors on `ArbOpportunity` to keep existing UI bindings working

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9378a31dc8329b58e2c5c1958570a