### PR TITLE
Rename arbitrage opportunity model

### DIFF
--- a/ArbitrageOpportunity.swift
+++ b/ArbitrageOpportunity.swift
@@ -1,15 +1,17 @@
 import Foundation
 
-public struct ArbOpportunity: Identifiable, Hashable, Sendable {
+public struct ArbitrageOpportunity: Identifiable, Hashable, Sendable {
     public let id = UUID()
-    public let pair: String
+    public let tokenPair: String
     public let buyExchange: String
     public let sellExchange: String
     public let buyPrice: Double
     public let sellPrice: Double
     public let timestamp: Date
 
-    public var spread: Double { sellPrice - buyPrice }
-    /// e.g. 0.012 = 1.2%
-    public var spreadPct: Double { (sellPrice - buyPrice) / buyPrice }
+    /// Absolute profit between the buy and sell legs.
+    public var profit: Double { sellPrice - buyPrice }
+
+    /// Percentage spread expressed as a fraction (0.01 = 1%).
+    public var spread: Double { (sellPrice - buyPrice) / buyPrice }
 }

--- a/ArbitrageService.swift
+++ b/ArbitrageService.swift
@@ -70,9 +70,13 @@ final class ArbitrageService {
         }
     }
 
-    func findOpportunities(for pair: String, minProfit: Double = 0) async throws -> [ArbOpportunity] {
+    func findOpportunities(for pair: String, minProfit: Double = 0) async throws -> [ArbitrageOpportunity] {
         guard await isSubscribed(.standard) else { return [] }
         let quotes = try await fetchQuotes(for: pair)
         return ArbDetector.detect(quotes: quotes, minProfit: minProfit)
+    }
+
+    func findOpportunities(quotes: [MarketQuote], minProfit: Double = 0) -> [ArbitrageOpportunity] {
+        ArbDetector.detect(quotes: quotes, minProfit: minProfit)
     }
 }

--- a/Services/ArbDetector.swift
+++ b/Services/ArbDetector.swift
@@ -2,9 +2,8 @@ import Foundation
 
 enum ArbDetector {
     /// `minProfit` is a fraction (0.01 = 1%)
-    static func detect(quotes: [MarketQuote], minProfit: Double) -> [ArbOpportunity] {
+    static func detect(quotes: [MarketQuote], minProfit: Double) -> [ArbitrageOpportunity] {
         guard quotes.count >= 2 else { return [] }
-        /Users/space/FlashArb/Services/ArbDetector.swift:5:70 'ArbOpportunity' is ambiguous for type lookup in this context
 
         // best buy = lowest price, best sell = highest price across exchanges
         guard let bestBuy  = quotes.min(by: { $0.price < $1.price }),
@@ -15,8 +14,8 @@ enum ArbDetector {
         guard spreadPct >= minProfit else { return [] }
 
         return [
-            ArbOpportunity(
-                pair: bestBuy.tokenPair,
+            ArbitrageOpportunity(
+                tokenPair: bestBuy.tokenPair,
                 buyExchange: bestBuy.exchange,
                 sellExchange: bestSell.exchange,
                 buyPrice: bestBuy.price,


### PR DESCRIPTION
## Summary
- rename the arbitrage opportunity model to `ArbitrageOpportunity` and expose UI-facing fields with computed profit/spread accessors
- update the detector to build the renamed model
- adjust the service helpers to return the new type for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d93788554c83298a11db6b49c0928f