### PR TITLE
Improve dashboard onboarding, help, and empty states

### DIFF
--- a/Sources/UI/Dashboard/DashboardView.swift
+++ b/Sources/UI/Dashboard/DashboardView.swift
@@ -8,55 +8,107 @@ struct DashboardView: View {
     @State private var showConfirmation = false
     @State private var executionStatus: String?
     @State private var showPaywall = false
+    @State private var showHowItWorks = false
 
     var body: some View {
         NavigationView {
             List {
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Welcome to FlashArb")
+                            .font(.headline)
+                        Text("Start with a simple setup: connect an exchange, pick a pair, and track opportunities.")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        Button("How FlashArb works") {
+                            showHowItWorks = true
+                        }
+                        .font(.subheadline)
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                Section(header: Text("Quick Start")) {
+                    Label("Connect an exchange account", systemImage: "link")
+                    Label("Choose a pair to monitor", systemImage: "chart.line.uptrend.xyaxis")
+                    Label("Enable alerts for price gaps", systemImage: "bell.badge")
+                }
+
+                Section(header: Text("Overview")) {
+                    HStack {
+                        Text("Assets tracked")
+                        Spacer()
+                        Text("\(viewModel.portfolio.positions.count)")
+                            .foregroundColor(.secondary)
+                    }
+                    HStack {
+                        Text("Pairs monitored")
+                        Spacer()
+                        Text("\(Set(viewModel.quotes.map(\.tokenPair)).count)")
+                            .foregroundColor(.secondary)
+                    }
+                }
+
                 Section(header: Text("Portfolio")) {
-                    ForEach(viewModel.portfolio.positions, id: \.token) { position in
-                        HStack {
-                            Text(position.token)
-                            Spacer()
-                            Text(String(format: "%.4f", position.amount))
-                                .foregroundColor(.secondary)
+                    if viewModel.portfolio.positions.isEmpty {
+                        Text("No assets yet. Connect an exchange to import balances.")
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(viewModel.portfolio.positions, id: \.token) { position in
+                            HStack {
+                                Text(position.token)
+                                Spacer()
+                                Text(String(format: "%.4f", position.amount))
+                                    .foregroundColor(.secondary)
+                            }
                         }
                     }
                 }
 
                 Section(header: Text("Live Prices")) {
-                    ForEach(viewModel.quotes, id: \.tokenPair) { quote in
-                        HStack {
-                            VStack(alignment: .leading) {
-                                Text(quote.tokenPair)
-                                Text(quote.exchange)
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
+                    if viewModel.quotes.isEmpty {
+                        Text("Add a pair to see live pricing updates.")
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(viewModel.quotes, id: \.tokenPair) { quote in
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(quote.tokenPair)
+                                    Text(quote.exchange)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                Text(String(format: "%.4f", quote.price))
+                                    .bold()
                             }
-                            Spacer()
-                            Text(String(format: "%.4f", quote.price))
-                                .bold()
                         }
                     }
                 }
 
                 Section(header: Text("Opportunities")) {
-                    ForEach(viewModel.opportunities, id: \.tokenPair) { opp in
-                        Button {
-                            executingOpportunity = opp
-                            showConfirmation = true
-                        } label: {
-                            HStack {
-                                VStack(alignment: .leading) {
-                                    Text(opp.tokenPair)
-                                    Text("Buy: \(opp.buyExchange) @ \(opp.buyPrice, specifier: "%.4f")")
-                                        .font(.caption)
-                                    Text("Sell: \(opp.sellExchange) @ \(opp.sellPrice, specifier: "%.4f")")
-                                        .font(.caption)
+                    if viewModel.opportunities.isEmpty {
+                        Text("Opportunities appear when price gaps are detected.")
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(viewModel.opportunities, id: \.tokenPair) { opp in
+                            Button {
+                                executingOpportunity = opp
+                                showConfirmation = true
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading) {
+                                        Text(opp.tokenPair)
+                                        Text("Buy: \(opp.buyExchange) @ \(opp.buyPrice, specifier: "%.4f")")
+                                            .font(.caption)
+                                        Text("Sell: \(opp.sellExchange) @ \(opp.sellPrice, specifier: "%.4f")")
+                                            .font(.caption)
+                                    }
+                                    Spacer()
+                                    Text("Profit: \(opp.profit, specifier: "%.4f")")
+                                        .bold()
+                                        .foregroundColor(opp.profit > 0 ? .green : .red)
                                 }
-                                Spacer()
-                                Text("Profit: \(opp.profit, specifier: "%.4f")")
-                                    .bold()
-                                    .foregroundColor(opp.profit > 0 ? .green : .red)
                             }
                         }
                     }
@@ -71,7 +123,13 @@ struct DashboardView: View {
             }
             .navigationTitle("Dashboard")
             .toolbar {
+                Button("Help") { showHowItWorks = true }
                 Button("Upgrade") { showPaywall = true }
+            }
+            .alert("How FlashArb Works", isPresented: $showHowItWorks) {
+                Button("Got it", role: .cancel) { }
+            } message: {
+                Text("FlashArb watches prices across exchanges and highlights spreads. Start by connecting an exchange and choosing a pair to monitor.")
             }
             .confirmationDialog("Execute trade?", isPresented: $showConfirmation, presenting: executingOpportunity) { opp in
                 Button("Confirm") {
@@ -139,6 +197,4 @@ final class DashboardViewModel: ObservableObject {
         }
     }
 }
-
-
 


### PR DESCRIPTION
### Motivation
- Make the Dashboard friendlier for new users by surfacing a short onboarding flow and quick-start guidance. 
- Reduce confusion when no data is present by providing clear empty-state messaging and counts. 
- Provide an obvious help entry point so users can learn how FlashArb works before connecting exchanges.

### Description
- Added a welcome panel and a `Quick Start` section to `Sources/UI/Dashboard/DashboardView.swift` with simple instructions and labeled actions. 
- Added an `Overview` section that shows asset and unique pair counts using `Set(viewModel.quotes.map(\.tokenPair)).count`. 
- Added empty-state messages for Portfolio, Live Prices, and Opportunities so the UI explains what to do when data is missing. 
- Added a `Help` toolbar button, a `showHowItWorks` state, and an alert explaining how FlashArb works; removed the previously-added `uniqued()` array extension and replaced its usage with `Set`.

### Testing
- No automated tests were executed for this change because it is a UI-only update and no test suite was run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e4fe35dc8329bdcb0d0d8cfcef18)